### PR TITLE
Add evil-pinyin-start-pattern

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,13 +37,13 @@
 #+END_SRC
 
 ** 一般变量
-| Variable                     | Buffer local | Description              | Default                                     |
-|------------------------------+--------------+--------------------------+---------------------------------------------|
-| evil-pinyin-scheme           | yes          | 汉语拼音方案             | ~simplified-quanpin-all~                    |
-| evil-pinyin-with-search-rule | yes          | 打开 ~/~ 和 ~?~ 搜索功能 | 'custom.                                    |
-| evil-pinyin-start-pattern    | yes          | 搜索起始符号             | 默认为感叹号开启，即: ~/!hy~ 可以匹配“汉语” |
-| evil-pinyin-with-punctuation | yes          | 包含符号.                | ~t~                                         |
-|------------------------------+--------------+--------------------------+---------------------------------------------|
+| Variable                     | Buffer local | Description              | Default                                   |
+|------------------------------+--------------+--------------------------+-------------------------------------------|
+| evil-pinyin-scheme           | yes          | 汉语拼音方案             | ~simplified-quanpin-all~                  |
+| evil-pinyin-with-search-rule | yes          | 打开 ~/~ 和 ~?~ 搜索功能 | 'custom.                                  |
+| evil-pinyin-start-pattern    | yes          | 搜索起始符号             | 默认为冒号开启，即: ~/:hy~ 可以匹配“汉语” |
+| evil-pinyin-with-punctuation | yes          | 包含符号.                | ~t~                                       |
+|------------------------------+--------------+--------------------------+-------------------------------------------|
 
 ** 自定义码表
 #+BEGIN_SRC lisp

--- a/README.org
+++ b/README.org
@@ -37,12 +37,13 @@
 #+END_SRC
 
 ** 一般变量
-| Variable                     | Buffer local | Description              | Default                                         |
-|------------------------------+--------------+--------------------------+-------------------------------------------------|
-| evil-pinyin-scheme           | yes          | 汉语拼音方案             | ~simplified-quanpin-all~                        |
-| evil-pinyin-with-search-rule | yes          | 打开 ~/~ 和 ~?~ 搜索功能 | 'exclam.  感叹号开启，即: ~/!hy~ 可以匹配“汉语” |
-| evil-pinyin-with-punctuation | yes          | 包含符号.                | ~t~                                             |
-|------------------------------+--------------+--------------------------+-------------------------------------------------|
+| Variable                     | Buffer local | Description              | Default                                     |
+|------------------------------+--------------+--------------------------+---------------------------------------------|
+| evil-pinyin-scheme           | yes          | 汉语拼音方案             | ~simplified-quanpin-all~                    |
+| evil-pinyin-with-search-rule | yes          | 打开 ~/~ 和 ~?~ 搜索功能 | 'custom.                                    |
+| evil-pinyin-start-pattern    | yes          | 搜索起始符号             | 默认为感叹号开启，即: ~/!hy~ 可以匹配“汉语” |
+| evil-pinyin-with-punctuation | yes          | 包含符号.                | ~t~                                         |
+|------------------------------+--------------+--------------------------+---------------------------------------------|
 
 ** 自定义码表
 #+BEGIN_SRC lisp

--- a/evil-pinyin.el
+++ b/evil-pinyin.el
@@ -38,14 +38,18 @@
 ;;;###autoload
 (define-namespace evil-pinyin-
 
-(defvar with-search-rule 'always
+(defvar with-search-rule 'custom
   "Enable the /search/ feature.
 
 Possible values:
 - 'always: always disable pinyin search.
 - 'never: never enable pinyin search.
-- 'exclam: enable pinyin search when pattern started with `!'.")
+- 'custom: enable pinyin search when pattern started with, default `!'.")
 (make-variable-buffer-local 'evil-pinyin-with-search-rule)
+
+(defvar start-pattern "!"
+  "`evil-pinyin' start pattern.")
+(make-variable-buffer-local 'evil-pinyin-start-pattern)
 
 (defvar with-punctuation t
   "Include Chinese punctuation.")
@@ -328,11 +332,11 @@ ONLY-CHINESE-P: English characters are not included."
                     (eq with-search-rule 'always) t)
                    (; never
                     (eq with-search-rule 'never) nil)
-                   (; exclam
-                    (eq with-search-rule 'exclam)
-                    (and re (= (string-to-char re) ?!))))
+                   (; custom
+                    (eq with-search-rule 'custom)
+                    (and re (= (string-to-char re) (string-to-char start-pattern)))))
              (not (string-match-p "\[.*+?[\\$]" re)))
-        (-build-regexp (if (eq with-search-rule 'exclam) (substring re 1) re))
+        (-build-regexp (if (eq with-search-rule 'custom) (substring re 1) re))
       re)))
 
 (defun clear()

--- a/evil-pinyin.el
+++ b/evil-pinyin.el
@@ -44,10 +44,10 @@
 Possible values:
 - 'always: always disable pinyin search.
 - 'never: never enable pinyin search.
-- 'custom: enable pinyin search when pattern started with, default `!'.")
+- 'custom: enable pinyin search when pattern started with, default `:'.")
 (make-variable-buffer-local 'evil-pinyin-with-search-rule)
 
-(defvar start-pattern "!"
+(defvar start-pattern ":"
   "`evil-pinyin' start pattern.")
 (make-variable-buffer-local 'evil-pinyin-start-pattern)
 


### PR DESCRIPTION
顺便修正了源文件里的一处错误

README里写`evil-pinyin-with-search-rule`的默认模式是`exclam`，但源代码里默认是`always`，现在更改为`custom`了