### PR TITLE
Fix a typo in variable description.

### DIFF
--- a/evil-pinyin.el
+++ b/evil-pinyin.el
@@ -42,7 +42,7 @@
   "Enable the /search/ feature.
 
 Possible values:
-- 'always: always disable pinyin search.
+- 'always: always enable pinyin search.
 - 'never: never enable pinyin search.
 - 'custom: enable pinyin search when pattern started with, default `:'.")
 (make-variable-buffer-local 'evil-pinyin-with-search-rule)


### PR DESCRIPTION
The description of variable `evil-pinyin-with-search-rule' is wrong. As "always disable" has the same meaning as "never enable".